### PR TITLE
feat: Implement modal viewer for poems

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -195,3 +195,83 @@ ul.posts {
   #related h2 {
     margin-bottom: 1em;
   }
+
+/*****************************************************************************/
+/*
+/* Modal
+/*
+/*****************************************************************************/
+
+#poem-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: none;
+  z-index: 1000;
+}
+
+#poem-modal-content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: white;
+  padding: 20px;
+  border: 1px solid #ccc;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  width: 80%;
+  max-width: 600px;
+  max-height: 80vh;
+  overflow-y: auto;
+  display: none;
+  z-index: 1001;
+}
+
+#poem-modal-close {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 24px;
+  font-weight: bold;
+  cursor: pointer;
+  color: #aaa;
+}
+
+#poem-modal-close:hover {
+  color: #333;
+}
+
+#poem-modal-title {
+  margin-top: 0;
+  margin-bottom: 1em;
+  font-size: 1.5em;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.5em;
+}
+
+#poem-modal-body {
+  line-height: 1.6;
+}
+
+#poem-modal-navigation {
+  margin-top: 15px;
+  text-align: right;
+}
+
+#poem-modal-prev,
+#poem-modal-next {
+  padding: 8px 15px;
+  margin-left: 10px;
+  cursor: pointer;
+  border: 1px solid #ccc;
+  background-color: #f0f0f0;
+}
+
+#poem-modal-prev:disabled,
+#poem-modal-next:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/index.html
+++ b/index.html
@@ -22,325 +22,325 @@
 <h1>Произведения</h1>
 <ul class="posts">
   
-    <li><span>3 May 2014</span> &raquo; <a href="works/2014-05-03-nu_i_zhizn.html">Ну и жизнь!</a></li>
+    <li><span>3 May 2014</span> &raquo; <a href="works/2014-05-03-nu_i_zhizn.html" class="poem-link">Ну и жизнь!</a></li>
 
-    <li><span>27 Feb 2014</span> &raquo; <a href="works/2014-02-27-996186-gde_anukovic.html">Где Янукович?</a></li>
+    <li><span>27 Feb 2014</span> &raquo; <a href="works/2014-02-27-996186-gde_anukovic.html" class="poem-link">Где Янукович?</a></li>
   
-    <li><span>26 Feb 2014</span> &raquo; <a href="works/2014-02-26-995477-tak_vosstala_moa_ukraina.html">Так восстала моя Украина</a></li>
+    <li><span>26 Feb 2014</span> &raquo; <a href="works/2014-02-26-995477-tak_vosstala_moa_ukraina.html" class="poem-link">Так восстала моя Украина</a></li>
   
-    <li><span>23 Feb 2014</span> &raquo; <a href="works/2014-02-23-993841-bej_pervym_vitalij_otkrytoe_pis_mo_majdanovzev_v_klicko.html">Бей первым, Виталий! Открытое письмо майдановцев В. Кличко.</a></li>
+    <li><span>23 Feb 2014</span> &raquo; <a href="works/2014-02-23-993841-bej_pervym_vitalij_otkrytoe_pis_mo_majdanovzev_v_klicko.html" class="poem-link">Бей первым, Виталий! Открытое письмо майдановцев В. Кличко.</a></li>
   
-    <li><span>17 Feb 2014</span> &raquo; <a href="works/2014-02-17-989259-razgovor_s_poctal_onsej_o_revoluzii.html">Разговор с почтальоншей о революции</a></li>
+    <li><span>17 Feb 2014</span> &raquo; <a href="works/2014-02-17-989259-razgovor_s_poctal_onsej_o_revoluzii.html" class="poem-link">Разговор с почтальоншей о революции</a></li>
   
-    <li><span>16 Feb 2014</span> &raquo; <a href="works/2014-02-16-988167-kuharka_ukrainy_ili_monolog_prezidenta.html">Кухарка Украины, или Монолог Президента</a></li>
+    <li><span>16 Feb 2014</span> &raquo; <a href="works/2014-02-16-988167-kuharka_ukrainy_ili_monolog_prezidenta.html" class="poem-link">Кухарка Украины, или Монолог Президента</a></li>
   
-    <li><span>13 Feb 2014</span> &raquo; <a href="works/2014-02-13-986674-pul_verizazia_pohar_kovski.html">Пульверизация по-харьковски</a></li>
+    <li><span>13 Feb 2014</span> &raquo; <a href="works/2014-02-13-986674-pul_verizazia_pohar_kovski.html" class="poem-link">Пульверизация по-харьковски</a></li>
   
-    <li><span>10 Feb 2014</span> &raquo; <a href="works/2014-02-10-984359-ten__puskina.html">Тень Пушкина</a></li>
+    <li><span>10 Feb 2014</span> &raquo; <a href="works/2014-02-10-984359-ten__puskina.html" class="poem-link">Тень Пушкина</a></li>
   
-    <li><span>08 Feb 2014</span> &raquo; <a href="works/2014-02-08-982706-majdan_ne_sdaetsa.html">Майдан не сдаётся</a></li>
+    <li><span>08 Feb 2014</span> &raquo; <a href="works/2014-02-08-982706-majdan_ne_sdaetsa.html" class="poem-link">Майдан не сдаётся</a></li>
   
-    <li><span>02 Feb 2014</span> &raquo; <a href="works/2014-02-02-978049-sladkaa_jizn_.html">Сладкая жизнь</a></li>
+    <li><span>02 Feb 2014</span> &raquo; <a href="works/2014-02-02-978049-sladkaa_jizn_.html" class="poem-link">Сладкая жизнь</a></li>
   
-    <li><span>02 Feb 2014</span> &raquo; <a href="works/2014-02-02-977775-novaa_pesna_po_motivu_ruslana_doljenza.html">Новая песня. По мотиву Руслана Долженца</a></li>
+    <li><span>02 Feb 2014</span> &raquo; <a href="works/2014-02-02-977775-novaa_pesna_po_motivu_ruslana_doljenza.html" class="poem-link">Новая песня. По мотиву Руслана Долженца</a></li>
   
-    <li><span>16 Jan 2014</span> &raquo; <a href="works/2014-01-16-964827-lebedinoe_ozero.html">Лебединое озеро</a></li>
+    <li><span>16 Jan 2014</span> &raquo; <a href="works/2014-01-16-964827-lebedinoe_ozero.html" class="poem-link">Лебединое озеро</a></li>
   
-    <li><span>14 Jan 2014</span> &raquo; <a href="works/2014-01-14-963289-garmonia_zvukov_akrosonet.html">Гармония звуков. Акросонет</a></li>
+    <li><span>14 Jan 2014</span> &raquo; <a href="works/2014-01-14-963289-garmonia_zvukov_akrosonet.html" class="poem-link">Гармония звуков. Акросонет</a></li>
   
-    <li><span>14 Jan 2014</span> &raquo; <a href="works/2014-01-14-963099-na_cem_doljen_stoat__lenin.html">На чём должен стоять Ленин?</a></li>
+    <li><span>14 Jan 2014</span> &raquo; <a href="works/2014-01-14-963099-na_cem_doljen_stoat__lenin.html" class="poem-link">На чём должен стоять Ленин?</a></li>
   
-    <li><span>12 Jan 2014</span> &raquo; <a href="works/2014-01-12-961540-moi_lubimye_bermudy.html">Мои любимые Бермуды</a></li>
+    <li><span>12 Jan 2014</span> &raquo; <a href="works/2014-01-12-961540-moi_lubimye_bermudy.html" class="poem-link">Мои любимые Бермуды</a></li>
   
-    <li><span>11 Jan 2014</span> &raquo; <a href="works/2014-01-11-960724-rihter_svatoslav_akrostih.html">Рихтер Святослав. Акростих</a></li>
+    <li><span>11 Jan 2014</span> &raquo; <a href="works/2014-01-11-960724-rihter_svatoslav_akrostih.html" class="poem-link">Рихтер Святослав. Акростих</a></li>
   
-    <li><span>06 Jan 2014</span> &raquo; <a href="works/2014-01-06-957200-cto_proishodit_v_severnoj_koree.html">Что происходит в Северной Корее?</a></li>
+    <li><span>06 Jan 2014</span> &raquo; <a href="works/2014-01-06-957200-cto_proishodit_v_severnoj_koree.html" class="poem-link">Что происходит в Северной Корее?</a></li>
   
-    <li><span>05 Jan 2014</span> &raquo; <a href="works/2014-01-05-956559-predsmertnye_sudorogi_jivogo_gipsa.html">Предсмертные судороги живого гипса</a></li>
+    <li><span>05 Jan 2014</span> &raquo; <a href="works/2014-01-05-956559-predsmertnye_sudorogi_jivogo_gipsa.html" class="poem-link">Предсмертные судороги живого гипса</a></li>
   
-    <li><span>05 Jan 2014</span> &raquo; <a href="works/2014-01-05-956321-parohod_ekspromtparodia.html">Пароход. Экспромт-пародия</a></li>
+    <li><span>05 Jan 2014</span> &raquo; <a href="works/2014-01-05-956321-parohod_ekspromtparodia.html" class="poem-link">Пароход. Экспромт-пародия</a></li>
   
-    <li><span>04 Jan 2014</span> &raquo; <a href="works/2014-01-04-955653-selkuncik_akrostihsonet.html">Щелкунчик. Акростих-сонет</a></li>
+    <li><span>04 Jan 2014</span> &raquo; <a href="works/2014-01-04-955653-selkuncik_akrostihsonet.html" class="poem-link">Щелкунчик. Акростих-сонет</a></li>
   
-    <li><span>28 Dec 2013</span> &raquo; <a href="works/2013-12-28-951703-zarjal_uje_v_konusne_sinij_merin.html">Заржал уже в конюшне Синий Мерин</a></li>
+    <li><span>28 Dec 2013</span> &raquo; <a href="works/2013-12-28-951703-zarjal_uje_v_konusne_sinij_merin.html" class="poem-link">Заржал уже в конюшне Синий Мерин</a></li>
   
-    <li><span>28 Dec 2013</span> &raquo; <a href="works/2013-12-28-951426-ne_tol_ko_do_kolen_parodia_na_ssipaceva.html">Не только до колен. Пародия на С.Щипачёва</a></li>
+    <li><span>28 Dec 2013</span> &raquo; <a href="works/2013-12-28-951426-ne_tol_ko_do_kolen_parodia_na_ssipaceva.html" class="poem-link">Не только до колен. Пародия на С.Щипачёва</a></li>
   
-    <li><span>28 Dec 2013</span> &raquo; <a href="works/2013-12-28-951345-sekspir_i_muha_ili_v_gostah_u_marsaka_parodia.html">Шекспир и муха, или В гостях у Маршака. Пародия</a></li>
+    <li><span>28 Dec 2013</span> &raquo; <a href="works/2013-12-28-951345-sekspir_i_muha_ili_v_gostah_u_marsaka_parodia.html" class="poem-link">Шекспир и муха, или В гостях у Маршака. Пародия</a></li>
   
-    <li><span>28 Dec 2013</span> &raquo; <a href="works/2013-12-28-951332-razanskaa_zemla_akrostih.html">Рязанская земля. Акростих.</a></li>
+    <li><span>28 Dec 2013</span> &raquo; <a href="works/2013-12-28-951332-razanskaa_zemla_akrostih.html" class="poem-link">Рязанская земля. Акростих.</a></li>
   
-    <li><span>28 Dec 2013</span> &raquo; <a href="works/2013-12-28-951156-monolog_vlublennogo_medveda.html">Монолог влюблённого медведя</a></li>
+    <li><span>28 Dec 2013</span> &raquo; <a href="works/2013-12-28-951156-monolog_vlublennogo_medveda.html" class="poem-link">Монолог влюблённого медведя</a></li>
   
-    <li><span>27 Dec 2013</span> &raquo; <a href="works/2013-12-27-951129-vstreca_s_afrikankoj_v_odesskom_tramvae.html">Встреча с африканкой в одесском трамвае</a></li>
+    <li><span>27 Dec 2013</span> &raquo; <a href="works/2013-12-27-951129-vstreca_s_afrikankoj_v_odesskom_tramvae.html" class="poem-link">Встреча с африканкой в одесском трамвае</a></li>
   
-    <li><span>20 Dec 2013</span> &raquo; <a href="works/2013-12-20-945850-vory_v_palate_ili_gospital__dla_tarakanov.html">Воры в палате. или Госпиталь для тараканов</a></li>
+    <li><span>20 Dec 2013</span> &raquo; <a href="works/2013-12-20-945850-vory_v_palate_ili_gospital__dla_tarakanov.html" class="poem-link">Воры в палате. или Госпиталь для тараканов</a></li>
   
-    <li><span>16 Dec 2013</span> &raquo; <a href="works/2013-12-16-942790-perevody.html">Переводы</a></li>
+    <li><span>16 Dec 2013</span> &raquo; <a href="works/2013-12-16-942790-perevody.html" class="poem-link">Переводы</a></li>
   
-    <li><span>16 Dec 2013</span> &raquo; <a href="works/2013-12-16-942677-pejzaj_detstva_iz_antonio_macado.html">Пейзаж детства. Из Антонио Мачадо</a></li>
+    <li><span>16 Dec 2013</span> &raquo; <a href="works/2013-12-16-942677-pejzaj_detstva_iz_antonio_macado.html" class="poem-link">Пейзаж детства. Из Антонио Мачадо</a></li>
   
-    <li><span>15 Dec 2013</span> &raquo; <a href="works/2013-12-15-941739-verdikt_o_zaprete_dvijenia.html">Вердикт о запрете движения</a></li>
+    <li><span>15 Dec 2013</span> &raquo; <a href="works/2013-12-15-941739-verdikt_o_zaprete_dvijenia.html" class="poem-link">Вердикт о запрете движения</a></li>
   
-    <li><span>11 Dec 2013</span> &raquo; <a href="works/2013-12-11-937949-vojd__na_prodaju.html">Вождь на продажу</a></li>
+    <li><span>11 Dec 2013</span> &raquo; <a href="works/2013-12-11-937949-vojd__na_prodaju.html" class="poem-link">Вождь на продажу</a></li>
   
-    <li><span>09 Dec 2013</span> &raquo; <a href="works/2013-12-09-936497-pesna_predatela.html">Песня предателя</a></li>
+    <li><span>09 Dec 2013</span> &raquo; <a href="works/2013-12-09-936497-pesna_predatela.html" class="poem-link">Песня предателя</a></li>
   
-    <li><span>08 Dec 2013</span> &raquo; <a href="works/2013-12-08-936187-ekspromt_o_zavisti.html">Экспромт о зависти</a></li>
+    <li><span>08 Dec 2013</span> &raquo; <a href="works/2013-12-08-936187-ekspromt_o_zavisti.html" class="poem-link">Экспромт о зависти</a></li>
   
-    <li><span>07 Dec 2013</span> &raquo; <a href="works/2013-12-07-935294-podpolkovnik_mvd_za_rabotoj.html">Подполковник МВД за работой</a></li>
+    <li><span>07 Dec 2013</span> &raquo; <a href="works/2013-12-07-935294-podpolkovnik_mvd_za_rabotoj.html" class="poem-link">Подполковник МВД за работой</a></li>
   
-    <li><span>07 Dec 2013</span> &raquo; <a href="works/2013-12-07-935274-korol__rifm.html">Король рифм</a></li>
+    <li><span>07 Dec 2013</span> &raquo; <a href="works/2013-12-07-935274-korol__rifm.html" class="poem-link">Король рифм</a></li>
   
-    <li><span>05 Dec 2013</span> &raquo; <a href="works/2013-12-05-934223-dusa_safrana_iz_huana_ramona_himenesa.html">Душа шафрана. Из Хуана Рамона ХимЕнеса</a></li>
+    <li><span>05 Dec 2013</span> &raquo; <a href="works/2013-12-05-934223-dusa_safrana_iz_huana_ramona_himenesa.html" class="poem-link">Душа шафрана. Из Хуана Рамона ХимЕнеса</a></li>
   
-    <li><span>05 Dec 2013</span> &raquo; <a href="works/2013-12-05-933881-rassvet_u_kostra.html">Рассвет у костра</a></li>
+    <li><span>05 Dec 2013</span> &raquo; <a href="works/2013-12-05-933881-rassvet_u_kostra.html" class="poem-link">Рассвет у костра</a></li>
   
-    <li><span>05 Dec 2013</span> &raquo; <a href="works/2013-12-05-933582-provody.html">Проводы</a></li>
+    <li><span>05 Dec 2013</span> &raquo; <a href="works/2013-12-05-933582-provody.html" class="poem-link">Проводы</a></li>
   
-    <li><span>03 Dec 2013</span> &raquo; <a href="works/2013-12-03-932722-nepokorennyj_iz_aleksea_reznikova.html">Непокорённый. Из Алексея Резникова</a></li>
+    <li><span>03 Dec 2013</span> &raquo; <a href="works/2013-12-03-932722-nepokorennyj_iz_aleksea_reznikova.html" class="poem-link">Непокорённый. Из Алексея Резникова</a></li>
   
-    <li><span>01 Dec 2013</span> &raquo; <a href="works/2013-12-01-931210-oblacnye_freski_sonet_iz_aleksea_reznikova.html">Облачные фрески. Сонет. Из Алексея Резникова</a></li>
+    <li><span>01 Dec 2013</span> &raquo; <a href="works/2013-12-01-931210-oblacnye_freski_sonet_iz_aleksea_reznikova.html" class="poem-link">Облачные фрески. Сонет. Из Алексея Резникова</a></li>
   
-    <li><span>30 Nov 2013</span> &raquo; <a href="works/2013-11-30-930720-kust_sireni_iz_aleksea_reznikova.html">Куст сирени. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>30 Nov 2013</span> &raquo; <a href="works/2013-11-30-930720-kust_sireni_iz_aleksea_reznikova.html" class="poem-link">Куст сирени. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>29 Nov 2013</span> &raquo; <a href="works/2013-11-29-929667-sinij_tigr.html">Синий тигр</a></li>
+    <li><span>29 Nov 2013</span> &raquo; <a href="works/2013-11-29-929667-sinij_tigr.html" class="poem-link">Синий тигр</a></li>
   
-    <li><span>28 Nov 2013</span> &raquo; <a href="works/2013-11-28-928910-siren__parodia_na_avoznesenskogo_i_areznikova.html">Сирень. Пародия на А.Вознесенского и А.Резникова</a></li>
+    <li><span>28 Nov 2013</span> &raquo; <a href="works/2013-11-28-928910-siren__parodia_na_avoznesenskogo_i_areznikova.html" class="poem-link">Сирень. Пародия на А.Вознесенского и А.Резникова</a></li>
   
-    <li><span>28 Nov 2013</span> &raquo; <a href="works/2013-11-28-928700-smert__s_razgonu_iz_aleksea_reznikova.html">Смерть с разгону. Из Алексея Резникова</a></li>
+    <li><span>28 Nov 2013</span> &raquo; <a href="works/2013-11-28-928700-smert__s_razgonu_iz_aleksea_reznikova.html" class="poem-link">Смерть с разгону. Из Алексея Резникова</a></li>
   
-    <li><span>26 Nov 2013</span> &raquo; <a href="works/2013-11-26-927941-ekspromt_o_samoubijzah.html">Экспромт о самоубийцах</a></li>
+    <li><span>26 Nov 2013</span> &raquo; <a href="works/2013-11-26-927941-ekspromt_o_samoubijzah.html" class="poem-link">Экспромт о самоубийцах</a></li>
   
-    <li><span>24 Nov 2013</span> &raquo; <a href="works/2013-11-24-926437-kredo_palestinskogo_poeta.html">Кредо палестинского поэта</a></li>
+    <li><span>24 Nov 2013</span> &raquo; <a href="works/2013-11-24-926437-kredo_palestinskogo_poeta.html" class="poem-link">Кредо палестинского поэта</a></li>
   
-    <li><span>24 Nov 2013</span> &raquo; <a href="works/2013-11-24-926417-sonet_pro_korola.html">Сонет про короля</a></li>
+    <li><span>24 Nov 2013</span> &raquo; <a href="works/2013-11-24-926417-sonet_pro_korola.html" class="poem-link">Сонет про короля</a></li>
   
-    <li><span>23 Nov 2013</span> &raquo; <a href="works/2013-11-23-925354-ballada_pro_muja_kotoryj_prisel_s_raboty.html">Баллада про мужа, который пришёл с работы</a></li>
+    <li><span>23 Nov 2013</span> &raquo; <a href="works/2013-11-23-925354-ballada_pro_muja_kotoryj_prisel_s_raboty.html" class="poem-link">Баллада про мужа, который пришёл с работы</a></li>
   
-    <li><span>22 Nov 2013</span> &raquo; <a href="works/2013-11-22-924471-mne_b_vyjec__ih_ognem_satiry.html">Мне б выжечь их огнём сатиры!</a></li>
+    <li><span>22 Nov 2013</span> &raquo; <a href="works/2013-11-22-924471-mne_b_vyjec__ih_ognem_satiry.html" class="poem-link">Мне б выжечь их огнём сатиры!</a></li>
   
-    <li><span>21 Nov 2013</span> &raquo; <a href="works/2013-11-21-923763-gerodot_na_prospekte_dobrovol_skogo.html">Геродот на проспекте Добровольского</a></li>
+    <li><span>21 Nov 2013</span> &raquo; <a href="works/2013-11-21-923763-gerodot_na_prospekte_dobrovol_skogo.html" class="poem-link">Геродот на проспекте Добровольского</a></li>
   
-    <li><span>20 Nov 2013</span> &raquo; <a href="works/2013-11-20-922664-prizyv_ograblennogo.html">Призыв ограбленного</a></li>
+    <li><span>20 Nov 2013</span> &raquo; <a href="works/2013-11-20-922664-prizyv_ograblennogo.html" class="poem-link">Призыв ограбленного</a></li>
   
-    <li><span>19 Nov 2013</span> &raquo; <a href="works/2013-11-19-922065-prekrasnyj_mir_iz_aleksea_reznikova.html">Прекрасный мир. Из Алексея Резникова</a></li>
+    <li><span>19 Nov 2013</span> &raquo; <a href="works/2013-11-19-922065-prekrasnyj_mir_iz_aleksea_reznikova.html" class="poem-link">Прекрасный мир. Из Алексея Резникова</a></li>
   
-    <li><span>18 Nov 2013</span> &raquo; <a href="works/2013-11-18-921072-turemnyj_dvorik.html">Тюремный дворик</a></li>
+    <li><span>18 Nov 2013</span> &raquo; <a href="works/2013-11-18-921072-turemnyj_dvorik.html" class="poem-link">Тюремный дворик</a></li>
   
-    <li><span>17 Nov 2013</span> &raquo; <a href="works/2013-11-17-920444-v_kakoj_partii_a_sostou_iz_dagera_saleha.html">В какой партии я состою? Из Дагера Салеха</a></li>
+    <li><span>17 Nov 2013</span> &raquo; <a href="works/2013-11-17-920444-v_kakoj_partii_a_sostou_iz_dagera_saleha.html" class="poem-link">В какой партии я состою? Из Дагера Салеха</a></li>
   
-    <li><span>16 Nov 2013</span> &raquo; <a href="works/2013-11-16-919972-otkuda.html">Откуда?</a></li>
+    <li><span>16 Nov 2013</span> &raquo; <a href="works/2013-11-16-919972-otkuda.html" class="poem-link">Откуда?</a></li>
   
-    <li><span>15 Nov 2013</span> &raquo; <a href="works/2013-11-15-918957-znakom_tes__gangnus.html">Знакомьтесь: Гангнус!</a></li>
+    <li><span>15 Nov 2013</span> &raquo; <a href="works/2013-11-15-918957-znakom_tes__gangnus.html" class="poem-link">Знакомьтесь: Гангнус!</a></li>
   
-    <li><span>15 Nov 2013</span> &raquo; <a href="works/2013-11-15-918595-dve_reki_iz_aleksea_reznikova.html">Две реки. Из Алексея Резникова</a></li>
+    <li><span>15 Nov 2013</span> &raquo; <a href="works/2013-11-15-918595-dve_reki_iz_aleksea_reznikova.html" class="poem-link">Две реки. Из Алексея Резникова</a></li>
   
-    <li><span>14 Nov 2013</span> &raquo; <a href="works/2013-11-14-918512-po_cetvergam.html">По четвергам</a></li>
+    <li><span>14 Nov 2013</span> &raquo; <a href="works/2013-11-14-918512-po_cetvergam.html" class="poem-link">По четвергам</a></li>
   
-    <li><span>14 Nov 2013</span> &raquo; <a href="works/2013-11-14-917720-pis_mo_sergea_esenina_k__materi.html">Письмо Сергея Есенина к  матери</a></li>
+    <li><span>14 Nov 2013</span> &raquo; <a href="works/2013-11-14-917720-pis_mo_sergea_esenina_k__materi.html" class="poem-link">Письмо Сергея Есенина к  матери</a></li>
   
-    <li><span>13 Nov 2013</span> &raquo; <a href="works/2013-11-13-917324-recka_rubikon_iz_aleksea_reznikova.html">Речка Рубикон. Из Алексея Резникова</a></li>
+    <li><span>13 Nov 2013</span> &raquo; <a href="works/2013-11-13-917324-recka_rubikon_iz_aleksea_reznikova.html" class="poem-link">Речка Рубикон. Из Алексея Резникова</a></li>
   
-    <li><span>12 Nov 2013</span> &raquo; <a href="works/2013-11-12-916696-beshitrostnaa_trava_iz_aleksea_reznikova.html">Бесхитростная трава. Из Алексея Резникова</a></li>
+    <li><span>12 Nov 2013</span> &raquo; <a href="works/2013-11-12-916696-beshitrostnaa_trava_iz_aleksea_reznikova.html" class="poem-link">Бесхитростная трава. Из Алексея Резникова</a></li>
   
-    <li><span>12 Nov 2013</span> &raquo; <a href="works/2013-11-12-916463-cto_bylo_to_splylo_iz_aleksea_reznikova.html">Что было, то сплыло. Из Алексея Резникова</a></li>
+    <li><span>12 Nov 2013</span> &raquo; <a href="works/2013-11-12-916463-cto_bylo_to_splylo_iz_aleksea_reznikova.html" class="poem-link">Что было, то сплыло. Из Алексея Резникова</a></li>
   
-    <li><span>10 Nov 2013</span> &raquo; <a href="works/2013-11-10-915301-libretto_modesta_il_ica_cajkovskogo.html">Либретто Модеста Ильича Чайковского</a></li>
+    <li><span>10 Nov 2013</span> &raquo; <a href="works/2013-11-10-915301-libretto_modesta_il_ica_cajkovskogo.html" class="poem-link">Либретто Модеста Ильича Чайковского</a></li>
   
-    <li><span>10 Nov 2013</span> &raquo; <a href="works/2013-11-10-915118-opera_iolanta_akrostih.html">Опера "Иоланта". Акростих</a></li>
+    <li><span>10 Nov 2013</span> &raquo; <a href="works/2013-11-10-915118-opera_iolanta_akrostih.html" class="poem-link">Опера "Иоланта". Акростих</a></li>
   
-    <li><span>10 Nov 2013</span> &raquo; <a href="works/2013-11-10-914812-lucsij_sonet.html">Лучший сонет</a></li>
+    <li><span>10 Nov 2013</span> &raquo; <a href="works/2013-11-10-914812-lucsij_sonet.html" class="poem-link">Лучший сонет</a></li>
   
-    <li><span>10 Nov 2013</span> &raquo; <a href="works/2013-11-10-914810-sonet_o_telefonnom_zvonke.html">Сонет о телефонном звонке</a></li>
+    <li><span>10 Nov 2013</span> &raquo; <a href="works/2013-11-10-914810-sonet_o_telefonnom_zvonke.html" class="poem-link">Сонет о телефонном звонке</a></li>
   
-    <li><span>10 Nov 2013</span> &raquo; <a href="works/2013-11-10-914805-ballada_o_prizyvnike.html">Баллада о призывнике</a></li>
+    <li><span>10 Nov 2013</span> &raquo; <a href="works/2013-11-10-914805-ballada_o_prizyvnike.html" class="poem-link">Баллада о призывнике</a></li>
   
-    <li><span>09 Nov 2013</span> &raquo; <a href="works/2013-11-09-914509-duraka_ne_valaj_saganov__parodia.html">Дурака не валяй, Шаганов!  Пародия</a></li>
+    <li><span>09 Nov 2013</span> &raquo; <a href="works/2013-11-09-914509-duraka_ne_valaj_saganov__parodia.html" class="poem-link">Дурака не валяй, Шаганов!  Пародия</a></li>
   
-    <li><span>08 Nov 2013</span> &raquo; <a href="works/2013-11-08-913607-kak_lider_partii_udar_zasitil_doktorskuu.html">Как лидер партии "УДАР" защитил докторскую</a></li>
+    <li><span>08 Nov 2013</span> &raquo; <a href="works/2013-11-08-913607-kak_lider_partii_udar_zasitil_doktorskuu.html" class="poem-link">Как лидер партии "УДАР" защитил докторскую</a></li>
   
-    <li><span>07 Nov 2013</span> &raquo; <a href="works/2013-11-07-912941-pocemu_tak_iz_aleksea_reznikova.html">Почему так? Из Алексея Резникова</a></li>
+    <li><span>07 Nov 2013</span> &raquo; <a href="works/2013-11-07-912941-pocemu_tak_iz_aleksea_reznikova.html" class="poem-link">Почему так? Из Алексея Резникова</a></li>
   
-    <li><span>07 Nov 2013</span> &raquo; <a href="works/2013-11-07-912510-dve_korolevy.html">Две королевы</a></li>
+    <li><span>07 Nov 2013</span> &raquo; <a href="works/2013-11-07-912510-dve_korolevy.html" class="poem-link">Две королевы</a></li>
   
-    <li><span>06 Nov 2013</span> &raquo; <a href="works/2013-11-06-912489-evrejantisemit.html">Еврей-антисемит</a></li>
+    <li><span>06 Nov 2013</span> &raquo; <a href="works/2013-11-06-912489-evrejantisemit.html" class="poem-link">Еврей-антисемит</a></li>
   
-    <li><span>06 Nov 2013</span> &raquo; <a href="works/2013-11-06-912471-struna_paganini.html">Струна Паганини</a></li>
+    <li><span>06 Nov 2013</span> &raquo; <a href="works/2013-11-06-912471-struna_paganini.html" class="poem-link">Струна Паганини</a></li>
   
-    <li><span>06 Nov 2013</span> &raquo; <a href="works/2013-11-06-912427-fonar__pod_glazom.html">Фонарь под глазом</a></li>
+    <li><span>06 Nov 2013</span> &raquo; <a href="works/2013-11-06-912427-fonar__pod_glazom.html" class="poem-link">Фонарь под глазом</a></li>
   
-    <li><span>06 Nov 2013</span> &raquo; <a href="works/2013-11-06-912410-portret_reki_iz_aleksea_reznikova.html">Портрет реки. Из Алексея Резникова</a></li>
+    <li><span>06 Nov 2013</span> &raquo; <a href="works/2013-11-06-912410-portret_reki_iz_aleksea_reznikova.html" class="poem-link">Портрет реки. Из Алексея Резникова</a></li>
   
-    <li><span>05 Nov 2013</span> &raquo; <a href="works/2013-11-05-911429-kakim_azykom_razgovarivat__v_lifte.html">Каким языком разговаривать в лифте?</a></li>
+    <li><span>05 Nov 2013</span> &raquo; <a href="works/2013-11-05-911429-kakim_azykom_razgovarivat__v_lifte.html" class="poem-link">Каким языком разговаривать в лифте?</a></li>
   
-    <li><span>04 Nov 2013</span> &raquo; <a href="works/2013-11-04-910681-epigramma_na_stihotvorza.html">Эпиграмма на стихотворца</a></li>
+    <li><span>04 Nov 2013</span> &raquo; <a href="works/2013-11-04-910681-epigramma_na_stihotvorza.html" class="poem-link">Эпиграмма на стихотворца</a></li>
   
-    <li><span>04 Nov 2013</span> &raquo; <a href="works/2013-11-04-910671-skol_ko_sutok.html">Сколько суток...</a></li>
+    <li><span>04 Nov 2013</span> &raquo; <a href="works/2013-11-04-910671-skol_ko_sutok.html" class="poem-link">Сколько суток...</a></li>
   
-    <li><span>03 Nov 2013</span> &raquo; <a href="works/2013-11-03-909945-kompliment_neznakomki.html">Комплимент незнакомки</a></li>
+    <li><span>03 Nov 2013</span> &raquo; <a href="works/2013-11-03-909945-kompliment_neznakomki.html" class="poem-link">Комплимент незнакомки</a></li>
   
-    <li><span>03 Nov 2013</span> &raquo; <a href="works/2013-11-03-909538-nocnye_cudisa_iz_aleksea_reznikova.html">Ночные чудища. Из Алексея Резникова</a></li>
+    <li><span>03 Nov 2013</span> &raquo; <a href="works/2013-11-03-909538-nocnye_cudisa_iz_aleksea_reznikova.html" class="poem-link">Ночные чудища. Из Алексея Резникова</a></li>
   
-    <li><span>01 Nov 2013</span> &raquo; <a href="works/2013-11-01-908258-sprosite_iz_aleksea_reznikova.html">Спросите... Из Алексея Резникова</a></li>
+    <li><span>01 Nov 2013</span> &raquo; <a href="works/2013-11-01-908258-sprosite_iz_aleksea_reznikova.html" class="poem-link">Спросите... Из Алексея Резникова</a></li>
   
-    <li><span>01 Nov 2013</span> &raquo; <a href="works/2013-11-01-908245-kto_cem_dysit_iz_aleksea_reznikova.html">Кто чем дышит? Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>01 Nov 2013</span> &raquo; <a href="works/2013-11-01-908245-kto_cem_dysit_iz_aleksea_reznikova.html" class="poem-link">Кто чем дышит? Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>01 Nov 2013</span> &raquo; <a href="works/2013-11-01-908070-oda_dusesipatel_nomu_borzopiszu_iz_aleksea_reznikova.html">Ода душещипательному борзописцу. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>01 Nov 2013</span> &raquo; <a href="works/2013-11-01-908070-oda_dusesipatel_nomu_borzopiszu_iz_aleksea_reznikova.html" class="poem-link">Ода душещипательному борзописцу. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>31 Oct 2013</span> &raquo; <a href="works/2013-10-31-907599-p_anasie_gogoli_iz_aleksea_reznikova.html">Пьянящие Гоголи. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>31 Oct 2013</span> &raquo; <a href="works/2013-10-31-907599-p_anasie_gogoli_iz_aleksea_reznikova.html" class="poem-link">Пьянящие Гоголи. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>29 Oct 2013</span> &raquo; <a href="works/2013-10-29-906585-listovki_iz_aleksea_reznikova.html">Листовки. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>29 Oct 2013</span> &raquo; <a href="works/2013-10-29-906585-listovki_iz_aleksea_reznikova.html" class="poem-link">Листовки. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>28 Oct 2013</span> &raquo; <a href="works/2013-10-28-905747-na_rybnoj_lovle_po_motivu_skazki.html">На рыбной ловле. По мотиву сказки</a></li>
+    <li><span>28 Oct 2013</span> &raquo; <a href="works/2013-10-28-905747-na_rybnoj_lovle_po_motivu_skazki.html" class="poem-link">На рыбной ловле. По мотиву сказки</a></li>
   
-    <li><span>26 Oct 2013</span> &raquo; <a href="works/2013-10-26-904462-ballada_pro_musornogo_korola.html">Баллада про мусорного короля</a></li>
+    <li><span>26 Oct 2013</span> &raquo; <a href="works/2013-10-26-904462-ballada_pro_musornogo_korola.html" class="poem-link">Баллада про мусорного короля</a></li>
   
-    <li><span>26 Oct 2013</span> &raquo; <a href="works/2013-10-26-904234-telegramma_baraku_obame.html">Телеграмма Бараку Обаме</a></li>
+    <li><span>26 Oct 2013</span> &raquo; <a href="works/2013-10-26-904234-telegramma_baraku_obame.html" class="poem-link">Телеграмма Бараку Обаме</a></li>
   
-    <li><span>24 Oct 2013</span> &raquo; <a href="works/2013-10-24-902948-gasnusij_golos_iz_aleksea_reznikova.html">Гаснущий голос. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>24 Oct 2013</span> &raquo; <a href="works/2013-10-24-902948-gasnusij_golos_iz_aleksea_reznikova.html" class="poem-link">Гаснущий голос. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>24 Oct 2013</span> &raquo; <a href="works/2013-10-24-902613-igrausij_na__strunah_dojda__iz_aleksea_reznikova.html">Играющий на  струнах дождя.  Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>24 Oct 2013</span> &raquo; <a href="works/2013-10-24-902613-igrausij_na__strunah_dojda__iz_aleksea_reznikova.html" class="poem-link">Играющий на  струнах дождя.  Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>21 Oct 2013</span> &raquo; <a href="works/2013-10-21-900525-legenda_o_nemosnom_starze_eskiz_k_portretu_kgpaustovskogo.html">Легенда о немощном старце. Эскиз к портрету К.Г.Паустовского</a></li>
+    <li><span>21 Oct 2013</span> &raquo; <a href="works/2013-10-21-900525-legenda_o_nemosnom_starze_eskiz_k_portretu_kgpaustovskogo.html" class="poem-link">Легенда о немощном старце. Эскиз к портрету К.Г.Паустовского</a></li>
   
-    <li><span>19 Oct 2013</span> &raquo; <a href="works/2013-10-19-899546-pocemu_anukovic_ne_otpuskaet_timosenko_na_lecenie_v_germaniu.html">Почему Янукович не отпускает Тимошенко на лечение в Германию</a></li>
+    <li><span>19 Oct 2013</span> &raquo; <a href="works/2013-10-19-899546-pocemu_anukovic_ne_otpuskaet_timosenko_na_lecenie_v_germaniu.html" class="poem-link">Почему Янукович не отпускает Тимошенко на лечение в Германию</a></li>
   
-    <li><span>19 Oct 2013</span> &raquo; <a href="works/2013-10-19-899436-lis__na_odnu_lublu_smotret__a_ves_.html">Лишь на одну люблю смотреть я вещь</a></li>
+    <li><span>19 Oct 2013</span> &raquo; <a href="works/2013-10-19-899436-lis__na_odnu_lublu_smotret__a_ves_.html" class="poem-link">Лишь на одну люблю смотреть я вещь</a></li>
   
-    <li><span>19 Oct 2013</span> &raquo; <a href="works/2013-10-19-899391-ballada_o_dvuh_polotnzah.html">Баллада о двух полотнцах</a></li>
+    <li><span>19 Oct 2013</span> &raquo; <a href="works/2013-10-19-899391-ballada_o_dvuh_polotnzah.html" class="poem-link">Баллада о двух полотнцах</a></li>
   
-    <li><span>19 Oct 2013</span> &raquo; <a href="works/2013-10-19-899343-vsego_vajnee_parodia_na_stihi_aleksea_reznikova.html">Всего важнее. Пародия на стихи Алексея РЕЗНИКОВА</a></li>
+    <li><span>19 Oct 2013</span> &raquo; <a href="works/2013-10-19-899343-vsego_vajnee_parodia_na_stihi_aleksea_reznikova.html" class="poem-link">Всего важнее. Пародия на стихи Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>17 Oct 2013</span> &raquo; <a href="works/2013-10-17-897656-prihodit_zima.html">Приходит зима...</a></li>
+    <li><span>17 Oct 2013</span> &raquo; <a href="works/2013-10-17-897656-prihodit_zima.html" class="poem-link">Приходит зима...</a></li>
   
-    <li><span>16 Oct 2013</span> &raquo; <a href="works/2013-10-16-897153-ukrainskoj_respublike_c_im_imenem_mna_sudili_iz_a_r.html">УКРАИНСКОЙ РЕСПУБЛИКЕ, чьим именем мня судили. Из А. Р.</a></li>
+    <li><span>16 Oct 2013</span> &raquo; <a href="works/2013-10-16-897153-ukrainskoj_respublike_c_im_imenem_mna_sudili_iz_a_r.html" class="poem-link">УКРАИНСКОЙ РЕСПУБЛИКЕ, чьим именем мня судили. Из А. Р.</a></li>
   
-    <li><span>14 Oct 2013</span> &raquo; <a href="works/2013-10-14-895716-sonet_ob_ekskursii_v_sbu_iz_aleksea_reznikova.html">Сонет об экскурсии в СБУ. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>14 Oct 2013</span> &raquo; <a href="works/2013-10-14-895716-sonet_ob_ekskursii_v_sbu_iz_aleksea_reznikova.html" class="poem-link">Сонет об экскурсии в СБУ. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>13 Oct 2013</span> &raquo; <a href="works/2013-10-13-895345-mojes__stat__parodia_na_stihi_ivana_radcenko.html">Можешь стать... Пародия на стихи Ивана Рядченко</a></li>
+    <li><span>13 Oct 2013</span> &raquo; <a href="works/2013-10-13-895345-mojes__stat__parodia_na_stihi_ivana_radcenko.html" class="poem-link">Можешь стать... Пародия на стихи Ивана Рядченко</a></li>
   
-    <li><span>13 Oct 2013</span> &raquo; <a href="works/2013-10-13-895209-kolbasa_v_krymu_parodia_na_stihi_ivana_radcenko.html">Колбаса в Крыму. Пародия на стихи Ивана Рядченко</a></li>
+    <li><span>13 Oct 2013</span> &raquo; <a href="works/2013-10-13-895209-kolbasa_v_krymu_parodia_na_stihi_ivana_radcenko.html" class="poem-link">Колбаса в Крыму. Пародия на стихи Ивана Рядченко</a></li>
   
-    <li><span>09 Oct 2013</span> &raquo; <a href="works/2013-10-09-892456-v_mire_invalidov.html">В мире инвалидов</a></li>
+    <li><span>09 Oct 2013</span> &raquo; <a href="works/2013-10-09-892456-v_mire_invalidov.html" class="poem-link">В мире инвалидов</a></li>
   
-    <li><span>09 Oct 2013</span> &raquo; <a href="works/2013-10-09-892333-otkrovenie_ptizyliry.html">Откровение птицы-лиры</a></li>
+    <li><span>09 Oct 2013</span> &raquo; <a href="works/2013-10-09-892333-otkrovenie_ptizyliry.html" class="poem-link">Откровение птицы-лиры</a></li>
   
-    <li><span>09 Oct 2013</span> &raquo; <a href="works/2013-10-09-892191-sonet_pro_ukradusecku_podrajanie_alekseu_reznikovu.html">Сонет про Украдушечку. Подражание Алексею РЕЗНИКОВУ</a></li>
+    <li><span>09 Oct 2013</span> &raquo; <a href="works/2013-10-09-892191-sonet_pro_ukradusecku_podrajanie_alekseu_reznikovu.html" class="poem-link">Сонет про Украдушечку. Подражание Алексею РЕЗНИКОВУ</a></li>
   
-    <li><span>08 Oct 2013</span> &raquo; <a href="works/2013-10-08-891899-sonet_o_sosenke__iz_aleksea_reznikova.html">Сонет о сосенке.  Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>08 Oct 2013</span> &raquo; <a href="works/2013-10-08-891899-sonet_o_sosenke__iz_aleksea_reznikova.html" class="poem-link">Сонет о сосенке.  Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>08 Oct 2013</span> &raquo; <a href="works/2013-10-08-891588-jilibyli_ded_i_baba_iz_aleksea_reznikova.html">Жили-были дед и баба. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>08 Oct 2013</span> &raquo; <a href="works/2013-10-08-891588-jilibyli_ded_i_baba_iz_aleksea_reznikova.html" class="poem-link">Жили-были дед и баба. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>08 Oct 2013</span> &raquo; <a href="works/2013-10-08-891583-epigramma_na_musornuu_zarizu_iz_aleksea_reznikova.html">Эпиграмма на мусорную царицу. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>08 Oct 2013</span> &raquo; <a href="works/2013-10-08-891583-epigramma_na_musornuu_zarizu_iz_aleksea_reznikova.html" class="poem-link">Эпиграмма на мусорную царицу. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>07 Oct 2013</span> &raquo; <a href="works/2013-10-07-890841-kontakt_s_inoplanetankoj_iz_aleksea_reznikova.html">Контакт с инопланетянкой. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>07 Oct 2013</span> &raquo; <a href="works/2013-10-07-890841-kontakt_s_inoplanetankoj_iz_aleksea_reznikova.html" class="poem-link">Контакт с инопланетянкой. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>06 Oct 2013</span> &raquo; <a href="works/2013-10-06-890315-ballada_o_vodoplavausej_poetesse.html">Баллада о водоплавающей поэтессе</a></li>
+    <li><span>06 Oct 2013</span> &raquo; <a href="works/2013-10-06-890315-ballada_o_vodoplavausej_poetesse.html" class="poem-link">Баллада о водоплавающей поэтессе</a></li>
   
-    <li><span>06 Oct 2013</span> &raquo; <a href="works/2013-10-06-890213-krylatyj_sonet_iz_aleksea_reznikova.html">Крылатый сонет. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>06 Oct 2013</span> &raquo; <a href="works/2013-10-06-890213-krylatyj_sonet_iz_aleksea_reznikova.html" class="poem-link">Крылатый сонет. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>05 Oct 2013</span> &raquo; <a href="works/2013-10-05-889726-neudoboproiznosimaa_omonimia_iz_aleksea_reznikova.html">Неудобопроизносимая омонимия. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>05 Oct 2013</span> &raquo; <a href="works/2013-10-05-889726-neudoboproiznosimaa_omonimia_iz_aleksea_reznikova.html" class="poem-link">Неудобопроизносимая омонимия. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>05 Oct 2013</span> &raquo; <a href="works/2013-10-05-889626-neumelyj_portnajka_parodia_na_aleksea_reznikova.html">Неумелый портняжка. Пародия на Алексея РЕЗНИКОВА</a></li>
+    <li><span>05 Oct 2013</span> &raquo; <a href="works/2013-10-05-889626-neumelyj_portnajka_parodia_na_aleksea_reznikova.html" class="poem-link">Неумелый портняжка. Пародия на Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>03 Oct 2013</span> &raquo; <a href="works/2013-10-03-888371-dvuhstrunnaa_skripka.html">Двухструнная скрипка</a></li>
+    <li><span>03 Oct 2013</span> &raquo; <a href="works/2013-10-03-888371-dvuhstrunnaa_skripka.html" class="poem-link">Двухструнная скрипка</a></li>
   
-    <li><span>02 Oct 2013</span> &raquo; <a href="works/2013-10-02-887708-sonet_o_krivyh_zerkalah_iz_aleksea_reznikova.html">Сонет о кривых зеркалах. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>02 Oct 2013</span> &raquo; <a href="works/2013-10-02-887708-sonet_o_krivyh_zerkalah_iz_aleksea_reznikova.html" class="poem-link">Сонет о кривых зеркалах. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>01 Oct 2013</span> &raquo; <a href="works/2013-10-01-887396-jemcujnyj_sonet_iz_aleksea_reznikova.html">Жемчужный сонет. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>01 Oct 2013</span> &raquo; <a href="works/2013-10-01-887396-jemcujnyj_sonet_iz_aleksea_reznikova.html" class="poem-link">Жемчужный сонет. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>01 Oct 2013</span> &raquo; <a href="works/2013-10-01-887170-sonet_o_drevnem_vikinge_iz_aleksea_reznikova.html">Сонет о древнем викинге. Из Алексея Резникова</a></li>
+    <li><span>01 Oct 2013</span> &raquo; <a href="works/2013-10-01-887170-sonet_o_drevnem_vikinge_iz_aleksea_reznikova.html" class="poem-link">Сонет о древнем викинге. Из Алексея Резникова</a></li>
   
-    <li><span>30 Sep 2013</span> &raquo; <a href="works/2013-09-30-886939-sonet_o_zelenyh_elah_iz_aleksea_reznikova.html">Сонет о зелёных елях. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>30 Sep 2013</span> &raquo; <a href="works/2013-09-30-886939-sonet_o_zelenyh_elah_iz_aleksea_reznikova.html" class="poem-link">Сонет о зелёных елях. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>30 Sep 2013</span> &raquo; <a href="works/2013-09-30-886589-sonet_o_socinitel_stve_iz_aleksea_reznikova.html">Сонет о сочинительстве. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>30 Sep 2013</span> &raquo; <a href="works/2013-09-30-886589-sonet_o_socinitel_stve_iz_aleksea_reznikova.html" class="poem-link">Сонет о сочинительстве. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>29 Sep 2013</span> &raquo; <a href="works/2013-09-29-886311-krasivyj_sonet_iz_aleksea_reznikova.html">Красивый сонет. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>29 Sep 2013</span> &raquo; <a href="works/2013-09-29-886311-krasivyj_sonet_iz_aleksea_reznikova.html" class="poem-link">Красивый сонет. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>29 Sep 2013</span> &raquo; <a href="works/2013-09-29-886222-nezabyvaemoe_i_rodnoe_iz_aleksea_reznikova.html">Незабываемое и родное. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>29 Sep 2013</span> &raquo; <a href="works/2013-09-29-886222-nezabyvaemoe_i_rodnoe_iz_aleksea_reznikova.html" class="poem-link">Незабываемое и родное. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>28 Sep 2013</span> &raquo; <a href="works/2013-09-28-885661-odnorifmenki_iz_aleksea_reznikova.html">Однорифменки. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>28 Sep 2013</span> &raquo; <a href="works/2013-09-28-885661-odnorifmenki_iz_aleksea_reznikova.html" class="poem-link">Однорифменки. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>28 Sep 2013</span> &raquo; <a href="works/2013-09-28-885649-priznaki_odyski.html">Признаки одышки</a></li>
+    <li><span>28 Sep 2013</span> &raquo; <a href="works/2013-09-28-885649-priznaki_odyski.html" class="poem-link">Признаки одышки</a></li>
   
-    <li><span>28 Sep 2013</span> &raquo; <a href="works/2013-09-28-885286-konsul_tazia_kostoprava_ili_komp_uternaa_hirurgia.html">Консультация костоправа, или Компьютерная хирургия</a></li>
+    <li><span>28 Sep 2013</span> &raquo; <a href="works/2013-09-28-885286-konsul_tazia_kostoprava_ili_komp_uternaa_hirurgia.html" class="poem-link">Консультация костоправа, или Компьютерная хирургия</a></li>
   
-    <li><span>28 Sep 2013</span> &raquo; <a href="works/2013-09-28-885271-epigramma_na_vladimira_pisarenko.html">Эпиграмма на Владимира Писаренко</a></li>
+    <li><span>28 Sep 2013</span> &raquo; <a href="works/2013-09-28-885271-epigramma_na_vladimira_pisarenko.html" class="poem-link">Эпиграмма на Владимира Писаренко</a></li>
   
-    <li><span>28 Sep 2013</span> &raquo; <a href="works/2013-09-28-885261-soperniza.html">Соперница</a></li>
+    <li><span>28 Sep 2013</span> &raquo; <a href="works/2013-09-28-885261-soperniza.html" class="poem-link">Соперница</a></li>
   
-    <li><span>25 Sep 2013</span> &raquo; <a href="works/2013-09-25-883920-dumausie_dveri_parodia_na_kgpaustoskogo.html">Думающие двери. Пародия на К.Г.Паустоского</a></li>
+    <li><span>25 Sep 2013</span> &raquo; <a href="works/2013-09-25-883920-dumausie_dveri_parodia_na_kgpaustoskogo.html" class="poem-link">Думающие двери. Пародия на К.Г.Паустоского</a></li>
   
-    <li><span>25 Sep 2013</span> &raquo; <a href="works/2013-09-25-883915-epigramma_na_aleksea_reznikova.html">Эпиграмма на Алексея РЕЗНИКОВА</a></li>
+    <li><span>25 Sep 2013</span> &raquo; <a href="works/2013-09-25-883915-epigramma_na_aleksea_reznikova.html" class="poem-link">Эпиграмма на Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>25 Sep 2013</span> &raquo; <a href="works/2013-09-25-883906-iskusstvo_ubejdat____iz_aleksea_reznikova.html">Искусство убеждать.   Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>25 Sep 2013</span> &raquo; <a href="works/2013-09-25-883906-iskusstvo_ubejdat____iz_aleksea_reznikova.html" class="poem-link">Искусство убеждать.   Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>25 Sep 2013</span> &raquo; <a href="works/2013-09-25-883860-epigramma_na_buhgaltera_iz_aleksea_reznikova.html">Эпиграмма на бухгалтера. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>25 Sep 2013</span> &raquo; <a href="works/2013-09-25-883860-epigramma_na_buhgaltera_iz_aleksea_reznikova.html" class="poem-link">Эпиграмма на бухгалтера. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>24 Sep 2013</span> &raquo; <a href="works/2013-09-24-883379-ne_poavilas__iz_aleksea_reznikova.html">Не появилась. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>24 Sep 2013</span> &raquo; <a href="works/2013-09-24-883379-ne_poavilas__iz_aleksea_reznikova.html" class="poem-link">Не появилась. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>24 Sep 2013</span> &raquo; <a href="works/2013-09-24-883292-meteorologiceskoe_iz_aleksea_reznikova.html">Метеорологическое. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>24 Sep 2013</span> &raquo; <a href="works/2013-09-24-883292-meteorologiceskoe_iz_aleksea_reznikova.html" class="poem-link">Метеорологическое. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>24 Sep 2013</span> &raquo; <a href="works/2013-09-24-882785-prijdi_iz_aleksea_reznikova.html">Прийди! Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>24 Sep 2013</span> &raquo; <a href="works/2013-09-24-882785-prijdi_iz_aleksea_reznikova.html" class="poem-link">Прийди! Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>23 Sep 2013</span> &raquo; <a href="works/2013-09-23-882443-raskovannost__iz_aleksea_reznikova.html">Раскованность. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>23 Sep 2013</span> &raquo; <a href="works/2013-09-23-882443-raskovannost__iz_aleksea_reznikova.html" class="poem-link">Раскованность. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>22 Sep 2013</span> &raquo; <a href="works/2013-09-22-881795-radost__pereselenia_iz_aleksea_reznikova.html">Радость переселения. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>22 Sep 2013</span> &raquo; <a href="works/2013-09-22-881795-radost__pereselenia_iz_aleksea_reznikova.html" class="poem-link">Радость переселения. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>22 Sep 2013</span> &raquo; <a href="works/2013-09-22-881642-sonet_o_borse_iz_aleksea_reznikova.html">Сонет о борще. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>22 Sep 2013</span> &raquo; <a href="works/2013-09-22-881642-sonet_o_borse_iz_aleksea_reznikova.html" class="poem-link">Сонет о борще. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>21 Sep 2013</span> &raquo; <a href="works/2013-09-21-881296-harakteristika_moskvy_glazami_cervivogo_mectatela.html">Характеристика Москвы глазами червивого мечтателя</a></li>
+    <li><span>21 Sep 2013</span> &raquo; <a href="works/2013-09-21-881296-harakteristika_moskvy_glazami_cervivogo_mectatela.html" class="poem-link">Характеристика Москвы глазами червивого мечтателя</a></li>
   
-    <li><span>19 Sep 2013</span> &raquo; <a href="works/2013-09-19-880397-odessa_pozdnim_vecerom_iz_aleksea_reznikova.html">Одесса поздним вечером. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>19 Sep 2013</span> &raquo; <a href="works/2013-09-19-880397-odessa_pozdnim_vecerom_iz_aleksea_reznikova.html" class="poem-link">Одесса поздним вечером. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>19 Sep 2013</span> &raquo; <a href="works/2013-09-19-880086-monolog_vulkana_iz_aleksea_reznikova.html">Монолог вулкана. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>19 Sep 2013</span> &raquo; <a href="works/2013-09-19-880086-monolog_vulkana_iz_aleksea_reznikova.html" class="poem-link">Монолог вулкана. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>18 Sep 2013</span> &raquo; <a href="works/2013-09-18-879482-ne_probujdaj_vo_mne_zvera_iz_aleksea_reznikova.html">Не пробуждай во мне зверя! Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>18 Sep 2013</span> &raquo; <a href="works/2013-09-18-879482-ne_probujdaj_vo_mne_zvera_iz_aleksea_reznikova.html" class="poem-link">Не пробуждай во мне зверя! Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>18 Sep 2013</span> &raquo; <a href="works/2013-09-18-879444-na_ekzamene_i_posle.html">На экзамене и после</a></li>
+    <li><span>18 Sep 2013</span> &raquo; <a href="works/2013-09-18-879444-na_ekzamene_i_posle.html" class="poem-link">На экзамене и после</a></li>
   
-    <li><span>18 Sep 2013</span> &raquo; <a href="works/2013-09-18-879409-ekspromt_o_pervom_sahtere.html">Экспромт о первом шахтёре</a></li>
+    <li><span>18 Sep 2013</span> &raquo; <a href="works/2013-09-18-879409-ekspromt_o_pervom_sahtere.html" class="poem-link">Экспромт о первом шахтёре</a></li>
   
-    <li><span>18 Sep 2013</span> &raquo; <a href="works/2013-09-18-879382-vodopad__parodia_na_evgenia_vinokurova.html">ВОДОПАД.  Пародия на Евгения Винокурова</a></li>
+    <li><span>18 Sep 2013</span> &raquo; <a href="works/2013-09-18-879382-vodopad__parodia_na_evgenia_vinokurova.html" class="poem-link">ВОДОПАД.  Пародия на Евгения Винокурова</a></li>
   
-    <li><span>17 Sep 2013</span> &raquo; <a href="works/2013-09-17-878764-utro_v_odesse.html">Утро в Одессе</a></li>
+    <li><span>17 Sep 2013</span> &raquo; <a href="works/2013-09-17-878764-utro_v_odesse.html" class="poem-link">Утро в Одессе</a></li>
   
-    <li><span>16 Sep 2013</span> &raquo; <a href="works/2013-09-16-878268-certovsina.html">Чертовщина</a></li>
+    <li><span>16 Sep 2013</span> &raquo; <a href="works/2013-09-16-878268-certovsina.html" class="poem-link">Чертовщина</a></li>
   
-    <li><span>16 Sep 2013</span> &raquo; <a href="works/2013-09-16-878245-razgovor_o_plastinke.html">Разговор о пластинке</a></li>
+    <li><span>16 Sep 2013</span> &raquo; <a href="works/2013-09-16-878245-razgovor_o_plastinke.html" class="poem-link">Разговор о пластинке</a></li>
   
-    <li><span>15 Sep 2013</span> &raquo; <a href="works/2013-09-15-877674-temperamentnyj_deduska_pereosmyslennaa_skazka.html">Темпераментный дедушка. Переосмысленная сказка</a></li>
+    <li><span>15 Sep 2013</span> &raquo; <a href="works/2013-09-15-877674-temperamentnyj_deduska_pereosmyslennaa_skazka.html" class="poem-link">Темпераментный дедушка. Переосмысленная сказка</a></li>
   
-    <li><span>15 Sep 2013</span> &raquo; <a href="works/2013-09-15-877570-v_gostah_u_evgenia_cernosvitova_v_moskve.html">В гостях у Евгения Черносвитова в Москве</a></li>
+    <li><span>15 Sep 2013</span> &raquo; <a href="works/2013-09-15-877570-v_gostah_u_evgenia_cernosvitova_v_moskve.html" class="poem-link">В гостях у Евгения Черносвитова в Москве</a></li>
   
-    <li><span>15 Sep 2013</span> &raquo; <a href="works/2013-09-15-877536-paustovskij_v_taruse.html">Паустовский в Тарусе</a></li>
+    <li><span>15 Sep 2013</span> &raquo; <a href="works/2013-09-15-877536-paustovskij_v_taruse.html" class="poem-link">Паустовский в Тарусе</a></li>
   
-    <li><span>14 Sep 2013</span> &raquo; <a href="works/2013-09-14-877253-a_opozdal_takie_probki.html">"Я опоздал, такие пробки!"</a></li>
+    <li><span>14 Sep 2013</span> &raquo; <a href="works/2013-09-14-877253-a_opozdal_takie_probki.html" class="poem-link">"Я опоздал, такие пробки!"</a></li>
   
-    <li><span>14 Sep 2013</span> &raquo; <a href="works/2013-09-14-877089-marafet_v_turemnoj_kamere_iz_aleksea_reznikova.html">Марафет в тюремной камере. Из Алексея РЕЗНИКОВА</a></li>
+    <li><span>14 Sep 2013</span> &raquo; <a href="works/2013-09-14-877089-marafet_v_turemnoj_kamere_iz_aleksea_reznikova.html" class="poem-link">Марафет в тюремной камере. Из Алексея РЕЗНИКОВА</a></li>
   
-    <li><span>14 Sep 2013</span> &raquo; <a href="works/2013-09-14-877001-stihi_o_diplome_na_araboizrail_skuu_temu.html">Стихи о дипломе на арабо-израильскую тему</a></li>
+    <li><span>14 Sep 2013</span> &raquo; <a href="works/2013-09-14-877001-stihi_o_diplome_na_araboizrail_skuu_temu.html" class="poem-link">Стихи о дипломе на арабо-израильскую тему</a></li>
   
-    <li><span>14 Sep 2013</span> &raquo; <a href="works/2013-09-14-876905-i_cemu_je_solohov_ucit_skol_nikov.html">И чему же Шолохов учит школьников?</a></li>
+    <li><span>14 Sep 2013</span> &raquo; <a href="works/2013-09-14-876905-i_cemu_je_solohov_ucit_skol_nikov.html" class="poem-link">И чему же Шолохов учит школьников?</a></li>
   
-    <li><span>13 Sep 2013</span> &raquo; <a href="works/2013-09-13-876497-sestnadzatoe_sentabra.html">Шестнадцатое сентября</a></li>
+    <li><span>13 Sep 2013</span> &raquo; <a href="works/2013-09-13-876497-sestnadzatoe_sentabra.html" class="poem-link">Шестнадцатое сентября</a></li>
   
-    <li><span>12 Sep 2013</span> &raquo; <a href="works/2013-09-12-875665-ubilejnoe_sobytie_ili_pravo_vybora.html">Юбилейное событие, или Право выбора</a></li>
+    <li><span>12 Sep 2013</span> &raquo; <a href="works/2013-09-12-875665-ubilejnoe_sobytie_ili_pravo_vybora.html" class="poem-link">Юбилейное событие, или Право выбора</a></li>
   
-    <li><span>11 Sep 2013</span> &raquo; <a href="works/2013-09-11-875527-plac_devy.html">Плач девы</a></li>
+    <li><span>11 Sep 2013</span> &raquo; <a href="works/2013-09-11-875527-plac_devy.html" class="poem-link">Плач девы</a></li>
   
-    <li><span>11 Sep 2013</span> &raquo; <a href="works/2013-09-11-875508-na_zvanom_obede.html">На званом обеде</a></li>
+    <li><span>11 Sep 2013</span> &raquo; <a href="works/2013-09-11-875508-na_zvanom_obede.html" class="poem-link">На званом обеде</a></li>
   
-    <li><span>11 Sep 2013</span> &raquo; <a href="works/2013-09-11-875149-ekzameny_sdaval_a_na_filfak.html">ЭКЗАМЕНЫ СДАВАЛ Я НА ФИЛФАК</a></li>
+    <li><span>11 Sep 2013</span> &raquo; <a href="works/2013-09-11-875149-ekzameny_sdaval_a_na_filfak.html" class="poem-link">ЭКЗАМЕНЫ СДАВАЛ Я НА ФИЛФАК</a></li>
   
-    <li><span>10 Sep 2013</span> &raquo; <a href="works/2013-09-10-874672-skazka_o_puskinegerasime_i_treh_korovah_skol_noe_socinenie.html">Сказка о Пушкине,Герасиме и трёх коровах. Школьное сочинение</a></li>
+    <li><span>10 Sep 2013</span> &raquo; <a href="works/2013-09-10-874672-skazka_o_puskinegerasime_i_treh_korovah_skol_noe_socinenie.html" class="poem-link">Сказка о Пушкине,Герасиме и трёх коровах. Школьное сочинение</a></li>
   
-    <li><span>10 Sep 2013</span> &raquo; <a href="works/2013-09-10-874652-kurat_li_korovy.html">КУРЯТ ЛИ КОРОВЫ?</a></li>
+    <li><span>10 Sep 2013</span> &raquo; <a href="works/2013-09-10-874652-kurat_li_korovy.html" class="poem-link">КУРЯТ ЛИ КОРОВЫ?</a></li>
   
-    <li><span>10 Sep 2013</span> &raquo; <a href="works/2013-09-10-874645-ustami_mladenza.html">УСТАМИ МЛАДЕНЦА...</a></li>
+    <li><span>10 Sep 2013</span> &raquo; <a href="works/2013-09-10-874645-ustami_mladenza.html" class="poem-link">УСТАМИ МЛАДЕНЦА...</a></li>
   
-    <li><span>10 Sep 2013</span> &raquo; <a href="works/2013-09-10-874617-i_pal_zem_ne_tronet.html">И пальцем не тронет...</a></li>
+    <li><span>10 Sep 2013</span> &raquo; <a href="works/2013-09-10-874617-i_pal_zem_ne_tronet.html" class="poem-link">И пальцем не тронет...</a></li>
   
     <li><span>10 Sep 2013</span> &raquo; <a href="works/2013-09-10-874417-moa_ob_asnitel_naa.html">Моя объяснительная</a></li>
   
@@ -2268,6 +2268,6 @@
 
 <!-- Google Analytics -->
 <!-- Google Analytics end -->
-
+<script src="/js/modal.js" defer></script>
 </body>
 </html>

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,0 +1,110 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modalHTML = `
+    <div id="poem-modal-overlay"></div>
+    <div id="poem-modal-content">
+      <span id="poem-modal-close">&times;</span>
+      <h2 id="poem-modal-title"></h2>
+      <div id="poem-modal-body"></div>
+      <div id="poem-modal-navigation">
+        <button id="poem-modal-prev">Previous</button>
+        <button id="poem-modal-next">Next</button>
+      </div>
+    </div>
+  `;
+
+  let modalAppended = false;
+  const poemList = [];
+  let currentPoemIndex = -1;
+
+  const poemLinkElements = document.querySelectorAll('a.poem-link');
+  poemLinkElements.forEach(link => {
+    poemList.push({
+      href: link.getAttribute('href'),
+      title: link.textContent.trim()
+    });
+  });
+
+  function updateButtonStates() {
+    const prevButton = document.getElementById('poem-modal-prev');
+    const nextButton = document.getElementById('poem-modal-next');
+
+    if (!prevButton || !nextButton) return; // Buttons not in DOM yet
+
+    prevButton.disabled = (currentPoemIndex <= 0);
+    nextButton.disabled = (currentPoemIndex >= poemList.length - 1);
+  }
+
+  async function loadPoemInModal(index) {
+    if (index < 0 || index >= poemList.length) {
+      console.error("Index out of bounds for poemList:", index);
+      return;
+    }
+    currentPoemIndex = index;
+    const poemURL = poemList[index].href;
+
+    document.getElementById('poem-modal-title').innerText = 'Loading...';
+    document.getElementById('poem-modal-body').innerHTML = '<p>Loading content...</p>';
+    updateButtonStates(); // Update button states early
+
+    try {
+      const response = await fetch(poemURL);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const poemHtmlText = await response.text();
+      
+      const parser = new DOMParser();
+      const poemDoc = parser.parseFromString(poemHtmlText, 'text/html');
+      
+      const title = poemDoc.querySelector('title')?.innerText || poemList[index].title || 'Poem';
+      const postDiv = poemDoc.querySelector('#post');
+      const bodyContent = postDiv ? postDiv.innerHTML : '<p>Content not found.</p>';
+      
+      document.getElementById('poem-modal-title').innerText = title;
+      document.getElementById('poem-modal-body').innerHTML = bodyContent;
+      
+    } catch (error) {
+      console.error('Error fetching poem:', error);
+      document.getElementById('poem-modal-title').innerText = 'Error';
+      document.getElementById('poem-modal-body').innerHTML = `<p>Could not load poem. ${error.message}</p>`;
+    }
+    updateButtonStates(); // Final update after loading
+  }
+
+  function showModal() {
+    if (!modalAppended) {
+      document.body.insertAdjacentHTML('beforeend', modalHTML);
+      modalAppended = true;
+      document.getElementById('poem-modal-close').addEventListener('click', closeModal);
+      document.getElementById('poem-modal-overlay').addEventListener('click', closeModal);
+      document.getElementById('poem-modal-prev').addEventListener('click', () => {
+        if (currentPoemIndex > 0) {
+          loadPoemInModal(currentPoemIndex - 1);
+        }
+      });
+      document.getElementById('poem-modal-next').addEventListener('click', () => {
+        if (currentPoemIndex < poemList.length - 1) {
+          loadPoemInModal(currentPoemIndex + 1);
+        }
+      });
+    }
+    document.getElementById('poem-modal-overlay').style.display = 'block';
+    document.getElementById('poem-modal-content').style.display = 'block';
+  }
+
+  function closeModal() {
+    document.getElementById('poem-modal-overlay').style.display = 'none';
+    document.getElementById('poem-modal-content').style.display = 'none';
+    document.getElementById('poem-modal-title').innerHTML = '';
+    document.getElementById('poem-modal-body').innerHTML = '';
+    currentPoemIndex = -1; // Reset index
+  }
+
+  poemLinkElements.forEach((link, index) => {
+    link.addEventListener('click', (event) => {
+      event.preventDefault();
+      showModal();
+      loadPoemInModal(index);
+    });
+  });
+});

--- a/new.html
+++ b/new.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
+<head>
+   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+   <title>Неопубликованные</title>
+   <meta name="author" content="Анатолий Яни" />
+
+   <!-- Homepage CSS -->
+   <link rel="stylesheet" href="/css/screen.css" type="text/css" media="screen, projection" />
+
+</head>
+<body>
+
+<div class="site">
+  <div class="title">
+    <a href="/">Анатолий Яни</a>
+  </div>
+  
+  <h1>Неопубликованные</h1>
+
+<p>Здесь будет представлен список неопубликованных произведений.</p>
+
+  
+  <div class="footer">
+    <div class="contact">
+      <p>
+        Анатолий Яни<br />
+        Поэт, пародист, переводчик<br />
+      </p>
+    </div>
+    <div class="contact">
+      <p>
+        <a href="http://www.neizvestniy-geniy.ru/users/2630.html">neizvestniy-geniy.ru</a><br />
+        <a href="http://www.stihi.in.ua/avtor.php?author=47289">stihi.in.ua</a><br />
+        <a href="http://grafomanam.net/users/4086">grafomanam.net</a><br />
+        <a href="https://www.proza.ru/avtor/acrol">proza.ru</a>
+      </p>
+    </div>
+  </div>
+</div>
+
+
+<!-- Google Analytics -->
+<!-- Google Analytics end -->
+
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a modal viewer for individual poems, enhancing your experience by allowing poems to be viewed without navigating away from the main list.

Key changes include:

- Added js/modal.js containing the JavaScript logic for:
  - Dynamically creating modal HTML.
  - Fetching poem content from individual HTML files using `fetch()` and `DOMParser`.
  - Displaying poem title and body in the modal.
  - Implementing "Next" and "Previous" poem navigation within the modal, based on the poem order in index.html.
  - Handling modal close via button and overlay click.
- Updated css/screen.css with styles for the modal overlay, content box, close button, and navigation buttons.
- Modified index.html:
  - Added class="poem-link" to all poem links in the "Произведения" list to enable JavaScript interaction.
  - Included a script tag for js/modal.js.
- Created new.html (listing "Неопубликованные" works) based on lost.html, with a placeholder message as the content for these poems is confirmed to be lost. Poems in lost.html and new.html are not linked to the modal viewer due to missing content.

The modal viewer provides a more seamless way to read poems. Navigation within the modal allows you to easily browse through the collection listed on index.html.